### PR TITLE
fix(jfrog): open up to non-prob notebooks

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -787,7 +787,7 @@ func generateNetworkPolicies(profile *kubeflowv1.Profile) []*networkingv1.Networ
 	port8082 := intstr.FromInt(8082)
 	policies = append(policies, &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "jfrog-egress",
+			Name:      "allow-jfrog-egress",
 			Namespace: profile.Name,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),


### PR DESCRIPTION
Allow non-prob notebooks to access jfrog.
Am unsure of the name change in the metadata (does it need to be changed somewhere else as well?)