### PR TITLE
fix(authpolicy): add all collaborators to the auth policy list

### DIFF
--- a/cmd/authpolicy.go
+++ b/cmd/authpolicy.go
@@ -9,20 +9,20 @@ import (
 	"github.com/StatCan/profiles-controller/pkg/controllers/profiles"
 	kubeflowclientset "github.com/StatCan/profiles-controller/pkg/generated/clientset/versioned"
 	kubeflowinformers "github.com/StatCan/profiles-controller/pkg/generated/informers/externalversions"
-	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
-
 	"github.com/StatCan/profiles-controller/pkg/signals"
 	"github.com/spf13/cobra"
 	istiosecurity "istio.io/api/security/v1beta1"
 	istiosecurityclient "istio.io/client-go/pkg/apis/security/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
+	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
@@ -30,34 +30,6 @@ import (
 
 const useridheader = "kubeflow-userid"
 const useridprefix = ""
-
-// Get all contributors on a namespace
-func generateAccessList(profileName string, roleBindingsLister rbacv1listers.RoleBindingLister) ([]string, error) {
-	access := []string{}
-
-	// Find contributors in namespaces
-	roleBindings, err := roleBindingsLister.RoleBindings(profileName).List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, roleBinding := range roleBindings {
-		if val, ok := roleBinding.Annotations["role"]; !ok || val != "edit" {
-			continue
-		}
-
-		for _, subject := range roleBinding.Subjects {
-			if subject.APIGroup != "rbac.authorization.k8s.io" || subject.Kind != "User" {
-				klog.Warningf("skipping non-user membership on role binding %s in namespace %s", roleBinding.Name, roleBinding.Namespace)
-				continue
-			}
-
-			access = append(access, subject.Name)
-		}
-	}
-
-	return access, nil
-}
 
 var authPoliciesCmd = &cobra.Command{
 	Use:   "auth-policies",
@@ -93,17 +65,18 @@ var authPoliciesCmd = &cobra.Command{
 		kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Minute*5)
 		kubeflowInformerFactory := kubeflowinformers.NewSharedInformerFactory(kubeflowClient, time.Minute*5)
 		istioInformerFactory := istioinformers.NewSharedInformerFactory(istioClient, time.Minute*5)
+		profilesInformer := kubeflowInformerFactory.Kubeflow().V1().Profiles()
+		profilesLister := profilesInformer.Lister()
 		authPolicyInformer := istioInformerFactory.Security().V1beta1().AuthorizationPolicies()
 		authPolicyLister := authPolicyInformer.Lister()
-		rbacInformer := kubeInformerFactory.Rbac().V1().RoleBindings()
-		rbacLister := rbacInformer.Lister()
+		roleBindingInformer := kubeInformerFactory.Rbac().V1().RoleBindings()
+		roleBindingLister := roleBindingInformer.Lister()
 
 		// Setup controller
 		controller := profiles.NewController(
-			kubeflowInformerFactory.Kubeflow().V1().Profiles(),
+			profilesInformer,
 			func(profile *kubeflowv1.Profile) error {
-
-				collaborators, err := generateAccessList(profile.Name, rbacLister)
+				collaborators, err := generateAccessList(profile.Name, roleBindingLister)
 				if err != nil {
 					return err
 				}
@@ -163,6 +136,44 @@ var authPoliciesCmd = &cobra.Command{
 			DeleteFunc: controller.HandleObject,
 		})
 
+		roleBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(new interface{}) {
+				newNP := new.(*rbac.RoleBinding)
+
+				profile, err := profilesLister.Get(newNP.Namespace)
+				if err != nil {
+					return
+				}
+
+				controller.EnqueueProfile(profile)
+			},
+			UpdateFunc: func(old, new interface{}) {
+				newNP := new.(*rbac.RoleBinding)
+				oldNP := old.(*rbac.RoleBinding)
+
+				if newNP.ResourceVersion == oldNP.ResourceVersion {
+					return
+				}
+
+				profile, err := profilesLister.Get(newNP.Namespace)
+				if err != nil {
+					return
+				}
+
+				controller.EnqueueProfile(profile)
+			},
+			DeleteFunc: func(old interface{}) {
+				oldNP := old.(*rbac.RoleBinding)
+
+				profile, err := profilesLister.Get(oldNP.Namespace)
+				if err != nil {
+					return
+				}
+
+				controller.EnqueueProfile(profile)
+			},
+		})
+
 		// Start informers
 		kubeInformerFactory.Start(stopCh)
 		kubeflowInformerFactory.Start(stopCh)
@@ -170,7 +181,7 @@ var authPoliciesCmd = &cobra.Command{
 
 		// Wait for caches
 		klog.Info("Waiting for informer caches to sync")
-		if ok := cache.WaitForCacheSync(stopCh, authPolicyInformer.Informer().GetController().HasSynced); !ok {
+		if ok := cache.WaitForCacheSync(stopCh, authPolicyInformer.Informer().GetController().HasSynced, roleBindingInformer.Informer().HasSynced); !ok {
 			klog.Fatalf("failed to wait for caches to sync")
 		}
 
@@ -192,6 +203,7 @@ func generateauthPolicies(profile *kubeflowv1.Profile, collaborators []string) [
 	}
 
 	authPolicies := []*istiosecurityclient.AuthorizationPolicy{}
+
 	authPolicies = append(authPolicies, &istiosecurityclient.AuthorizationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "namespace-owner-access-istio",
@@ -259,6 +271,34 @@ func generateauthPolicies(profile *kubeflowv1.Profile, collaborators []string) [
 	})
 
 	return authPolicies
+}
+
+// Get all contributors on a namespace
+func generateAccessList(profileName string, roleBindingsLister rbacv1listers.RoleBindingLister) ([]string, error) {
+	access := []string{}
+
+	// Find contributors in namespaces
+	roleBindings, err := roleBindingsLister.RoleBindings(profileName).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, roleBinding := range roleBindings {
+		if val, ok := roleBinding.Annotations["role"]; !ok || val != "edit" {
+			continue
+		}
+
+		for _, subject := range roleBinding.Subjects {
+			if subject.APIGroup != "rbac.authorization.k8s.io" || subject.Kind != "User" {
+				klog.Warningf("skipping non-user membership on role binding %s in namespace %s", roleBinding.Name, roleBinding.Namespace)
+				continue
+			}
+
+			access = append(access, subject.Name)
+		}
+	}
+
+	return access, nil
 }
 
 func init() {

--- a/pkg/controllers/profiles/controller.go
+++ b/pkg/controllers/profiles/controller.go
@@ -66,9 +66,9 @@ func NewController(
 	klog.Info("configuring event handlers")
 
 	profileInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controller.enqueueProfile,
+		AddFunc: controller.EnqueueProfile,
 		UpdateFunc: func(old, new interface{}) {
-			controller.enqueueProfile(new)
+			controller.EnqueueProfile(new)
 		},
 	})
 
@@ -188,10 +188,10 @@ func (c *Controller) syncHandler(key string) error {
 	return c.sync(profile)
 }
 
-// enqueueProfile takes a Profile resource and converts it into a namespace/name
+// EnqueueProfile takes a Profile resource and converts it into a namespace/name
 // string which is then put onto the work queue. This method should *not* be
 // passed resources of any type other than Profile.
-func (c *Controller) enqueueProfile(obj interface{}) {
+func (c *Controller) EnqueueProfile(obj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
@@ -236,7 +236,7 @@ func (c *Controller) HandleObject(obj interface{}) {
 			return
 		}
 
-		c.enqueueProfile(profile)
+		c.EnqueueProfile(profile)
 		return
 	}
 }


### PR DESCRIPTION
This adds the collaborators to the authpolicy; it uses the RoleBindings instead of the serviceRoleBindings, which is how kubeflow-opa-sync also does it

https://github.com/StatCan/aaw-kubeflow-opa-sync/blob/ecfb74f4ae283861a35b083fdd12b1b9041890af/main.go#L78