### PR TITLE
fix(quotas): set enourmous storage cap

### DIFF
--- a/cmd/quotas.go
+++ b/cmd/quotas.go
@@ -33,7 +33,7 @@ var defaultResources = corev1.ResourceList{
 	"limits.memory":   *resource.NewScaledQuantity(368, resource.Giga),
 
 	// Storage
-	"requests.storage": *resource.NewScaledQuantity(4, resource.Tera),
+	"requests.storage": *resource.NewScaledQuantity(100, resource.Tera),
 
 	// GPU
 	"requests.nvidia.com/gpu": *resource.NewQuantity(2, resource.DecimalSI),


### PR DESCRIPTION
Cranking this up to a huge number. So storage is still bounded, but won't interfere with the blob-csi PVCs

Closes https://github.com/StatCan/daaas/issues/1005