### PR TITLE
Fix @cbrown/gitea virtual service

### DIFF
--- a/cmd/gitea.go
+++ b/cmd/gitea.go
@@ -333,15 +333,24 @@ func generateIstioVirtualService(profile *kubeflowv1.Profile) (*istionetworkingc
 				},
 				{
 					Name: "gitea-redirect",
+					// TODO: this should be refactored once we upgrade to Kubeflow > 1.4,
+					// we will no longer need to check the http referer header once namespaced
+					// menu items are supported.
 					Match: []*istionetworkingv1beta1.HTTPMatchRequest{
 						{
 							Headers: map[string]*istionetworkingv1beta1.StringMatch{
-								// TODO: this should be refactored once we upgrade to Kubeflow > 1.4,
-								// we will no longer need to check the http referer header once namespaced
-								// menu items are supported.
 								"referer": {
 									MatchType: &istionetworkingv1beta1.StringMatch_Exact{
 										Exact: fmt.Sprintf("https://kubeflow.aaw-dev.cloud.statcan.ca/_/gitea/?ns=%s", namespace),
+									},
+								},
+							},
+						},
+						{
+							Headers: map[string]*istionetworkingv1beta1.StringMatch{
+								"referer": {
+									MatchType: &istionetworkingv1beta1.StringMatch_Exact{
+										Exact: fmt.Sprintf("https://kubeflow.aaw.cloud.statcan.ca/_/gitea/?ns=%s", namespace),
 									},
 								},
 							},

--- a/cmd/gitea.go
+++ b/cmd/gitea.go
@@ -337,7 +337,14 @@ func generateIstioVirtualService(profile *kubeflowv1.Profile) (*istionetworkingc
 						{
 							Uri: &istionetworkingv1beta1.StringMatch{
 								MatchType: &istionetworkingv1beta1.StringMatch_Prefix{
-									Prefix: fmt.Sprintf("/%s/?ns=%s", GITEA_SERVICE_URL, namespace),
+									Prefix: fmt.Sprintf("/%s/", GITEA_SERVICE_URL),
+								},
+							},
+							QueryParams: map[string]*istionetworkingv1beta1.StringMatch{
+								"ns": {
+									MatchType: &istionetworkingv1beta1.StringMatch_Exact{
+										Exact: namespace,
+									},
 								},
 							},
 						},

--- a/cmd/gitea.go
+++ b/cmd/gitea.go
@@ -335,15 +335,13 @@ func generateIstioVirtualService(profile *kubeflowv1.Profile) (*istionetworkingc
 					Name: "gitea-redirect",
 					Match: []*istionetworkingv1beta1.HTTPMatchRequest{
 						{
-							Uri: &istionetworkingv1beta1.StringMatch{
-								MatchType: &istionetworkingv1beta1.StringMatch_Prefix{
-									Prefix: fmt.Sprintf("/%s/", GITEA_SERVICE_URL),
-								},
-							},
-							QueryParams: map[string]*istionetworkingv1beta1.StringMatch{
-								"ns": {
+							Headers: map[string]*istionetworkingv1beta1.StringMatch{
+								// TODO: this should be refactored once we upgrade to Kubeflow > 1.4,
+								// we will no longer need to check the http referer header once namespaced
+								// menu items are supported.
+								"referer": {
 									MatchType: &istionetworkingv1beta1.StringMatch_Exact{
-										Exact: namespace,
+										Exact: fmt.Sprintf("https://kubeflow.aaw-dev.cloud.statcan.ca/_/gitea/?ns=%s", namespace),
 									},
 								},
 							},


### PR DESCRIPTION
The href on the Gitea button doesn't forward along the http parameter ns, so the rule matches on the referer header instead.