### PR TITLE
fix(parseutil.go): update strconv.Atoi() to contain the proper value

### DIFF
--- a/internal/util/parseutil.go
+++ b/internal/util/parseutil.go
@@ -20,7 +20,7 @@ func ParseEnvVar(envname string) string {
 // Parse an integer environment variable
 func ParseIntegerEnvVar(envname string) int {
 	value := ParseEnvVar(envname)
-	intVal, err := strconv.Atoi(envname)
+	intVal, err := strconv.Atoi(value)
 	if err != nil {
 		klog.Fatalf("Could not parse environment variable %s with values %s as an integer!", envname, value)
 	}


### PR DESCRIPTION
Closes Statcan/daaas#1180