### PR TITLE
feat(s3proxy): only create s3proxy instances on namespaces with opt-in label

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,20 @@
             "envFile": "${workspaceFolder}/.env"
         },
         {
+            "name": "Debug S3Proxy Profile Controller",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "cwd": "${workspaceFolder}",
+            "program": "main.go",
+            "args": [
+                "--kubeconfig",
+                "${env:KUBECONFIG}",
+                "s3proxy"
+            ],
+            "envFile": "${workspaceFolder}/.env"
+        },
+        {
             "name": "Debug Network Policy Profile Controller",
             "type": "go",
             "request": "launch",

--- a/cmd/s3proxy.go
+++ b/cmd/s3proxy.go
@@ -138,7 +138,7 @@ var s3proxyCmd = &cobra.Command{
 		controller := profiles.NewController(
 			kubeflowInformerFactory.Kubeflow().V1().Profiles(),
 			func(profile *kubeflowv1.Profile) error {
-				// See if the user has opted into source control; if not, then do not create s3proxy pods
+				// See if the user has opted into object storage; if not, then do not create s3proxy pods
 				var replicas int32
 
 				if val, ok := profile.Labels[s3EnabledLabel]; ok && val == "true" {


### PR DESCRIPTION
Reason is to reduce costs by not deploying unnecessary pods for users who don't need s3proxy.