### PR TITLE
@cbrown/deprecate netpols

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -575,83 +575,8 @@ func generateNetworkPolicies(profile *kubeflowv1.Profile) []*networkingv1.Networ
 	})
 
 	// Allow egress to Pipelines
-	port8888 := intstr.FromInt(8888)
-	port8887 := intstr.FromInt(8887)
 	port9000 := intstr.FromInt(9000)
 	port9001 := intstr.FromInt(9001)
-	policies = append(policies, &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "unclassified-pipelines-egress",
-			Namespace: profile.Name,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),
-			},
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "data.statcan.gc.ca/classification",
-						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"protected-b"},
-					},
-				},
-			},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
-			Egress: []networkingv1.NetworkPolicyEgressRule{
-				{
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: &protocolTCP,
-							Port:     &port8888,
-						},
-						{
-							Protocol: &protocolTCP,
-							Port:     &port8887,
-						},
-					},
-					To: []networkingv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"namespace.statcan.gc.ca/purpose": "daaas",
-								},
-							},
-							PodSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"app.kubernetes.io/name":      "kubeflow-pipelines",
-									"app.kubernetes.io/component": "ml-pipeline",
-								},
-							},
-						},
-					},
-				},
-				{
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: &protocolTCP,
-							Port:     &port9000,
-						},
-					},
-					To: []networkingv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"namespace.statcan.gc.ca/purpose": "daaas",
-								},
-							},
-							PodSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"app.kubernetes.io/name":      "minio",
-									"app.kubernetes.io/component": "minio",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
 
 	// Allow egress to MinIO
 	policies = append(policies, &networkingv1.NetworkPolicy{
@@ -1024,51 +949,6 @@ func generateNetworkPolicies(profile *kubeflowv1.Profile) []*networkingv1.Networ
 		})
 	}
 
-	// Allow ingress from system pods to s3proxy pods - this is necessary so that users can access
-	// the s3-explorer UI from within the Kubeflow interface.
-	policies = append(policies, &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "s3proxy-allow-ingress",
-			Namespace: profile.Name,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),
-			},
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "s3proxy",
-				},
-			},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{
-				{
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: &protocolTCP,
-							Port:     &portHttp,
-						},
-					},
-					From: []networkingv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"namespace.statcan.gc.ca/purpose": "system",
-								},
-							},
-						},
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"namespace.statcan.gc.ca/purpose": "daaas",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
 	// Allow egress from protb notebooks to the trino protb instance
 	policies = append(policies, &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -718,53 +718,6 @@ func generateNetworkPolicies(profile *kubeflowv1.Profile) []*networkingv1.Networ
 		},
 	})
 
-	portHttp := intstr.FromString("http")
-	// Allow ingress from the kubeflow gateway
-	policies = append(policies, &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gitea-allow-system-to-gitea",
-			Namespace: profile.Name,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),
-			},
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app":                        "gitea",
-					"app.kubernetes.io/instance": "gitea-unclassified",
-				},
-			},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{
-				{
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: &protocolTCP,
-							Port:     &portHttp,
-						},
-					},
-					From: []networkingv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"namespace.statcan.gc.ca/purpose": "system",
-								},
-							},
-						},
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"namespace.statcan.gc.ca/purpose": "daaas",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-
 	// Allow egress to postgres database for kubeflow profiles that opt into using Gitea.
 	val, labelExists := profile.ObjectMeta.Labels["sourcecontrol.statcan.gc.ca/enabled"]
 	profileOptsIntoSourceControl, _ := strconv.ParseBool(val)
@@ -811,6 +764,53 @@ func generateNetworkPolicies(profile *kubeflowv1.Profile) []*networkingv1.Networ
 		giteaPort80 := intstr.FromInt(80)
 		giteaPort22 := intstr.FromInt(22)
 		giteaPort3000 := intstr.FromInt(3000)
+		portHttp := intstr.FromString("http")
+
+		// Allow ingress from the kubeflow gateway
+		policies = append(policies, &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gitea-allow-system-to-gitea",
+				Namespace: profile.Name,
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),
+				},
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":                        "gitea",
+						"app.kubernetes.io/instance": "gitea-unclassified",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &protocolTCP,
+								Port:     &portHttp,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"namespace.statcan.gc.ca/purpose": "system",
+									},
+								},
+							},
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"namespace.statcan.gc.ca/purpose": "daaas",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
 		policies = append(policies, &networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "allow-gitea-http-egress-prot-b",


### PR DESCRIPTION
- make `s3proxy-allow-ingress` and `gitea-allow-system-to-gitea` only created if user profile has opt-in label
- deprecate `unclassified-pipelines-egress` netpol