### PR TITLE
removed blob-csi-mounts poddefault from controller

### DIFF
--- a/cmd/notebook.go
+++ b/cmd/notebook.go
@@ -130,27 +130,6 @@ func generatePodDefaults(profile *kubeflowv1.Profile) []*kubeflowv1alpha1.PodDef
 		},
 	})
 
-	defaults = append(defaults, &kubeflowv1alpha1.PodDefault{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blob-csi-mounts",
-			Namespace: profile.Name,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(profile, kubeflowv1.SchemeGroupVersion.WithKind("Profile")),
-			},
-		},
-		Spec: kubeflowv1alpha1.PodDefaultSpec{
-			Desc: "Mount Buckets to ~/buckets / Monter le stockage sur ~/buckets",
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"data.statcan.gc.ca/inject-blob-volumes": "true",
-				},
-			},
-			Annotations: map[string]string{
-				"data.statcan.gc.ca/inject-blob-volumes": "true",
-			},
-		},
-	})
-
 	// Default Protected B deny
 	defaults = append(defaults, &kubeflowv1alpha1.PodDefault{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Closing https://github.com/StatCan/daaas/issues/1578

Once this is merged, we can run the clean up command that is noted in the issue on dev to see if it works as intended before we run the clean-up on prod.