### PR TITLE
feat(check if s3 user exists): add helper function to check if s3 user exists

### DIFF
--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -90,7 +90,7 @@ func createUser(onPremName string, namespaceStr string, client *kubernetes.Clien
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(postBody))
 	req.Header.Set("Content-Type", "application/json")
 	// req.Header. // need to set other information
-	authorization := basicAuth(netappUser, netappUserSecret) // this must be confirmed)
+	authorization := base64.StdEncoding.EncodeToString([]byte(netappUser + ":" + netappUserSecret)) // this must be confirmed)
 	req.Header.Set("Authorization", "Basic "+authorization)
 	// resp, err := http.Post(url, "application/json", bytes.NewBuffer(postBody)) // cant use this because http.post does not allow for additional headers
 	//Handle Error

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -278,7 +278,7 @@ func performHttpGet(username string, password string, url string) (statusCode in
 	if err != nil {
 		klog.Fatalf("error sending and returning HTTP response  : %v", err)
 	}
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err = io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Fatalf("error sending and returning HTTP response  : %v", err)
 	}

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -88,7 +90,7 @@ func createUser(onPremName string, namespaceStr string, client *kubernetes.Clien
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(postBody))
 	req.Header.Set("Content-Type", "application/json")
 	// req.Header. // need to set other information
-	authorization := base64.StdEncoding.EncodeToString([]byte(netappUser + ":" + netappUserSecret)) // this must be confirmed)
+	authorization := basicAuth(netappUser, netappUserSecret) // this must be confirmed)
 	req.Header.Set("Authorization", "Basic "+authorization)
 	// resp, err := http.Post(url, "application/json", bytes.NewBuffer(postBody)) // cant use this because http.post does not allow for additional headers
 	//Handle Error
@@ -232,6 +234,68 @@ func checkExpired(labelValue string) bool {
 	return true
 	// Not found
 	return false
+}
+
+/*
+This will check for the existence of an S3 user
+https://docs.netapp.com/us-en/ontap-restapi/ontap/get-protocols-s3-services-users-.html
+Requires: svm.uuid, name, password and username for authentication
+Returns true if it does exist
+*/
+func checkIfS3UserExists(managementIP string, svmUuid string, onPremName string, username string, password string) bool {
+	// Build the request
+	//Encode the data
+	urlString := "https://" + managementIP + "/api/protocols/s3/services/" + svmUuid + "/users/" + onPremName
+	statusCode, _ := performHttpGet(username, password, urlString)
+	// if its 200
+	if statusCode == 200 {
+		return true
+	}
+	return false
+}
+
+/*
+Provides basic authentication
+*/
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+/*
+Does basic get for requests to the API. Returns the code and a json formatted response
+https://www.makeuseof.com/go-make-http-requests/
+apiPath should probably be /apiPath/
+*/
+func performHttpGet(username string, password string, url string) (statusCode int, responseBody []byte) {
+	// url := "https://" + managementIP + apiPath + filerUUID + "/users"
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Set("Content-Type", "application/json")
+	// req.Header. // need to set other information
+	authorization := basicAuth(username, password) // this must be confirmed)
+	req.Header.Set("Authorization", "Basic "+authorization)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		klog.Fatalf("error sending and returning HTTP response  : %v", err)
+	}
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		klog.Fatalf("error sending and returning HTTP response  : %v", err)
+	}
+	defer resp.Body.Close() // clean up memory
+	return resp.StatusCode, responseBody
+}
+
+// Format JSON data helper function
+func formatJSON(data []byte) string {
+	var out bytes.Buffer
+	err := json.Indent(&out, data, "", " ")
+
+	if err != nil {
+		fmt.Println(err)
+	}
+	d := out.Bytes()
+	return string(d)
 }
 
 var ontapcvoCmd = &cobra.Command{

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -239,7 +239,7 @@ func checkExpired(labelValue string) bool {
 /*
 This will check for the existence of an S3 user
 https://docs.netapp.com/us-en/ontap-restapi/ontap/get-protocols-s3-services-users-.html
-Requires: svm.uuid, name, password and username for authentication
+Requires: managementIP, svm.uuid, name, password and username for authentication
 Returns true if it does exist
 */
 func checkIfS3UserExists(managementIP string, svmUuid string, onPremName string, username string, password string) bool {
@@ -264,6 +264,7 @@ func basicAuth(username, password string) string {
 
 /*
 Does basic get for requests to the API. Returns the code and a json formatted response
+R
 https://www.makeuseof.com/go-make-http-requests/
 apiPath should probably be /apiPath/
 */
@@ -272,7 +273,7 @@ func performHttpGet(username string, password string, url string) (statusCode in
 	req, err := http.NewRequest("GET", url, nil)
 	req.Header.Set("Content-Type", "application/json")
 	// req.Header. // need to set other information
-	authorization := basicAuth(username, password) // this must be confirmed)
+	authorization := basicAuth(username, password)
 	req.Header.Set("Authorization", "Basic "+authorization)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
For [BTIS-476](https://jirab.statcan.ca/browse/BTIS-476). Also adds some helper functions that can be re-used by other commands. 
Note that these are kept as pluggable and playable as possible so that when we decide on order after everything has been done we can mess around then.

`basicAuth` is provided as a helper function to easily format for authentication.
`performHttpGet` performs a GET returning the `status code` and the `[]byte responseBody`
Where that `responseBody` can be formatted using the `formatJSON` function where in the future we need it. It currently is not used because the `checkIfS3UserExists` function only cares about seeing the [200 status from the api](https://docs.netapp.com/us-en/ontap-restapi/ontap/get-protocols-s3-services-users-.html#response)