### PR TITLE
chore(s3 account creation): improve and break out functionality

### DIFF
--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -264,7 +264,7 @@ func basicAuth(username, password string) string {
 
 /*
 Does basic get for requests to the API. Returns the code and a json formatted response
-R
+Requires username, password, and url.
 https://www.makeuseof.com/go-make-http-requests/
 apiPath should probably be /apiPath/
 */
@@ -281,7 +281,33 @@ func performHttpGet(username string, password string, url string) (statusCode in
 	}
 	responseBody, err = io.ReadAll(resp.Body)
 	if err != nil {
+		klog.Fatalf("error reading HTTP response  : %v", err)
+	}
+	defer resp.Body.Close() // clean up memory
+	return resp.StatusCode, responseBody
+}
+
+/*
+Does basic POST for requests to the API. Returns the code and a json formatted response
+Requires username, password, url, and the requestBody.
+An example requestBody assignment can look like
+
+	userData := []byte(`{"name":"` + name + `","job":"` + job + `"}`)
+	alternatively https://zetcode.com/golang/getpostrequest/
+*/
+func performHttpPost(username string, password string, url string, requestBody []byte) (statusCode int, responseBody []byte) {
+	// url := "https://" + managementIP + apiPath + filerUUID + "/users"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	authorization := basicAuth(username, password)
+	req.Header.Set("Authorization", "Basic "+authorization)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		klog.Fatalf("error sending and returning HTTP response  : %v", err)
+	}
+	responseBody, err = io.ReadAll(resp.Body)
+	if err != nil {
+		klog.Fatalf("error reading HTTP response  : %v", err)
 	}
 	defer resp.Body.Close() // clean up memory
 	return resp.StatusCode, responseBody

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -110,7 +110,6 @@ func createS3User(onPremName string, namespaceStr string, client *kubernetes.Cli
 			// All S3 buckets under the same SVM use the same ACCESS and SECRET to access them
 			"S3_ACCESS": []byte(postResponseFormatted.records[0].AccessKey),
 			"S3_SECRET": []byte(postResponseFormatted.records[0].SecretKey),
-			"S3_URL":    []byte(svmInfo.svmUrl),
 		},
 	}
 	_, err = client.CoreV1().Secrets(namespaceStr).Create(context.Background(), usersecret, metav1.CreateOptions{})

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -55,57 +55,69 @@ type s3KeysObj struct {
 	SecretKey string `json:"secret_key"`
 }
 
+type svmInfo struct {
+	svmName string
+	svmUrl  string
+	svmUUID string
+}
+
+// type svmInfoList struct {
+// 	svmInfos []svmInfo
+// }
+
+type managementInfo struct {
+	managementIP string
+	username     string
+	password     string
+}
+
 /*
-This will become the good function
-Requires the onPremname, the namespace to create the secret in, the current k8s client, the svmName, the svmUuId
-and the username and password for the management
+Requires the onPremname, the namespace to create the secret in, the current k8s client, the svmInfo and the managementInfo
 Returns true if successful
 */
-func createS3User(managementIP string, onPremName string, namespaceStr string, client *kubernetes.Clientset,
-	svmName string, svmURL string, svmUuId string, username string, password string) bool {
+func createS3User(onPremName string, namespaceStr string, client *kubernetes.Clientset, svmInfo svmInfo, mgmInfo managementInfo) bool {
 	postBody, _ := json.Marshal(map[string]interface{}{
 		"name": onPremName,
-		"svm": map[string]interface{}{
-			"uuid": svmUuId,
+		"svm": map[string]string{
+			"uuid": svmInfo.svmUUID,
 		},
 	})
-	url := "https://" + managementIP + "/api/protocols/s3/services/" + svmUuId + "/users"
-	statusCode, response := performHttpPost(username, password, url, postBody)
+	url := "https://" + mgmInfo.managementIP + "/api/protocols/s3/services/" + svmInfo.svmUUID + "/users"
+	statusCode, response := performHttpPost(mgmInfo.username, mgmInfo.password, url, postBody)
 
-	if statusCode == 201 {
-		klog.Infof("The S3 user was created. Proceeding to store SVM credentials")
-		// right now this is the only place we will create the secret, so I will just have it in here
-		postResponseFormatted := &createUserResponse{} // must decode the []byte response into something i can mess with
-		// need to determine if this unmarshals / converts to the struct correctly
-		err := json.Unmarshal(response, &postResponseFormatted)
-		if err != nil {
-			fmt.Println("Error in JSON unmarshalling from json marshalled object:", err)
-			return false
-		}
-		// Create the secret
-		usersecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      svmName + "-conn-secret", // change to be a const later or something
-				Namespace: namespaceStr,
-			},
-			Data: map[string][]byte{
-				// Nothing else needs to be in here; as the S3_BUCKET value should be somewhere else.
-				// All S3 buckets under the same SVM use the same ACCESS and SECRET to access them
-				"S3_ACCESS": []byte(postResponseFormatted.records[0].AccessKey),
-				"S3_SECRET": []byte(postResponseFormatted.records[0].SecretKey),
-				"S3_URL":    []byte(svmURL),
-			},
-		}
-		_, err = client.CoreV1().Secrets(namespaceStr).Create(context.Background(), usersecret, metav1.CreateOptions{})
-		if err != nil {
-			klog.Infof("An Error Occured while creating the secret %v", err)
-			return false
-		}
-		return true
-	} else {
+	if statusCode != 201 {
 		klog.Infof("An Error Occured while creating the S3 User")
 		return false
 	}
+	klog.Infof("The S3 user was created. Proceeding to store SVM credentials")
+	// right now this is the only place we will create the secret, so I will just have it in here
+	postResponseFormatted := &createUserResponse{} // must decode the []byte response into something i can mess with
+	// need to determine if this unmarshals / converts to the struct correctly
+	err := json.Unmarshal(response, &postResponseFormatted)
+	if err != nil {
+		fmt.Println("Error in JSON unmarshalling from json marshalled object:", err)
+		return false
+	}
+	// Create the secret
+	usersecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svmInfo.svmName + "-conn-secret", // change to be a const later or something
+			Namespace: namespaceStr,
+		},
+		Data: map[string][]byte{
+			// Nothing else needs to be in here; as the S3_BUCKET value should be somewhere else.
+			// All S3 buckets under the same SVM use the same ACCESS and SECRET to access them
+			"S3_ACCESS": []byte(postResponseFormatted.records[0].AccessKey),
+			"S3_SECRET": []byte(postResponseFormatted.records[0].SecretKey),
+			"S3_URL":    []byte(svmInfo.svmUrl),
+		},
+	}
+	_, err = client.CoreV1().Secrets(namespaceStr).Create(context.Background(), usersecret, metav1.CreateOptions{})
+	if err != nil {
+		klog.Infof("An Error Occured while creating the secret %v", err)
+		return false
+	}
+	return true
 }
 
 /*
@@ -172,7 +184,7 @@ Using the profile namespace, will use the configmap to retrieve a list of filers
 It will then iterate over the list and search for a constructed secret and if that secret is not found then we create
 the S3 user (and as a result the secret)
 */
-func checkSecrets(client *kubernetes.Clientset, profileName string, profileEmail string) bool {
+func checkSecrets(client *kubernetes.Clientset, profileName string, profileEmail string, mgmInfo managementInfo, svmInfo svmInfo) bool {
 	// We don't actually need secret informers, since informers look at changes in state
 	// https://www.macias.info/entry/202109081800_k8s_informers.md
 	// Get a list of secrets the user namespace should have accounts for using the configmap
@@ -188,8 +200,7 @@ func checkSecrets(client *kubernetes.Clientset, profileName string, profileEmail
 			onPremName, foundOnPrem := getOnPrem(profileEmail, client)
 			if foundOnPrem {
 				// Create the user
-				//wasSuccessful := createS3User(onPremName, profileName, client, k) // eventually change to createS3User
-				wasSuccessful := true
+				wasSuccessful := createS3User(onPremName, profileName, client, svmInfo, mgmInfo)
 				if !wasSuccessful {
 					klog.Info("Unable to create S3 user:" + onPremName)
 					return false
@@ -285,6 +296,22 @@ func performHttpPost(username string, password string, url string, requestBody [
 	return resp.StatusCode, responseBody
 }
 
+// TODO: Retrieve the svmInfo this must query the master configmap that exists in the DAS namespace.
+// This configmap COULD change, so could put this elsewhere and have it be one call.
+// How the mapping here works with naming will need to be settled on
+func getSvmInfo(client *kubernetes.Clientset, whichSVM string) svmInfo {
+
+	svmName := ""
+	svmUUID := ""
+	svmURL := ""
+	svmInformation := svmInfo{
+		svmName: svmName,
+		svmUUID: svmUUID,
+		svmUrl:  svmURL,
+	}
+	return svmInformation
+}
+
 // Format JSON data helper function
 func formatJSON(data []byte) string {
 	var out bytes.Buffer
@@ -333,6 +360,9 @@ var ontapcvoCmd = &cobra.Command{
 		//configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 		//configMapLister := configMapInformer.Lister()
 
+		// Obtain Management Info, as this does not change.
+		var mgmInfo = managementInfo{"", "", ""}
+		var svmInfo = svmInfo{"", "", ""}
 		// Setup controller
 		controller := profiles.NewController(
 			kubeflowInformerFactory.Kubeflow().V1().Profiles(),
@@ -341,7 +371,7 @@ var ontapcvoCmd = &cobra.Command{
 				for k, v := range allLabels {
 					// If the label we specify exists then look for the secret
 					if k == ontapLabel {
-						checkSecrets(kubeClient, profile.Name, profile.Spec.Owner.Name)
+						checkSecrets(kubeClient, profile.Name, profile.Spec.Owner.Name, mgmInfo, svmInfo)
 						if checkExpired(v) {
 							// Do things, but for first iteration may not care.
 							//klog.Infof("Expired, but not going to do anything yet")


### PR DESCRIPTION
[BTIS-477](https://jirab.statcan.ca/browse/BTIS-477). The old (now deleted in this PR) function did the HTTP POST in function, but that would definitely be used by the `CREATE BUCKET` function so to cut down on duplication it was extracted into its own function. 

**Note**: The function currently isn't called by anything and requires a lot of information to get going. The SVM url, UUID, and name should be retrieved by whatever calls this.

[Gist  about using unmarshal with the byte array](https://gist.github.com/Jose-Matsuda/dfd5a26fae843d67b3458cb14da06f67)