### PR TITLE
feat(ontap bucket creation): create buckets 

### DIFF
--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -72,6 +72,24 @@ type managementInfo struct {
 	password     string
 }
 
+type createBucketStruct struct {
+	Comment string
+	Name    string
+	NasPath string
+	Type    string
+	Policy  struct {
+		Statements []Statements
+	}
+}
+
+type Statements struct {
+	Effect     string
+	Actions    []string
+	Principals []interface{}
+	Resources  []string
+	Sid        string
+}
+
 /*
 Requires the onPremname, the namespace to create the secret in, the current k8s client, the svmInfo and the managementInfo
 Returns true if successful
@@ -129,15 +147,16 @@ that we should investigate and determine what to use.
 func createS3Bucket(svmInfo svmInfo, mgmInfo managementInfo, bucketName string, nasPath string) bool {
 	// As stated in the URL above, we need to build out our JSON post with all the necessary details
 	// Once we know the format and what to put in it should be easy.
-	hashedName := bucketName + "TODO- IMPLEMENT THIS"
-	postBody, _ := json.Marshal(map[string]interface{}{
-		"name": hashedName,
-		"svm": map[string]string{
-			"uuid": svmInfo.svmUUID,
-		},
-	})
+	hashedName := bucketName + "todo-implement-this"
+	//postBody := "{hello: hello}"
+	//postBody, _ := json.Marshal(object)
+	// Create a string that is valid json, as thats the simplest way of working with this request
+	// https://go.dev/play/p/sdBFnqDLIqS
+	jsonString := fmt.Sprintf(
+		`{"http":"%s"}`,
+		hashedName)
 	urlString := "https://" + mgmInfo.managementIP + "/api/protocols/s3/services/" + svmInfo.svmUUID + "/buckets"
-	statusCode, _ := performHttpPost(mgmInfo.username, mgmInfo.password, urlString, postBody)
+	statusCode, _ := performHttpPost(mgmInfo.username, mgmInfo.password, urlString, []byte(jsonString))
 	if statusCode == 202 {
 		klog.Infof("S3 Bucket job has been created: https://docs.netapp.com/us-en/ontap-restapi/ontap/post-protocols-s3-buckets.html#response")
 		return true

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -157,11 +157,13 @@ func createS3Bucket(svmInfo svmInfo, mgmInfo managementInfo, bucketName string, 
 	// https://discourse.gohugo.io/t/use-same-argument-twice-in-a-printf-clause/20398
 	urlString := "https://" + mgmInfo.managementIP + "/api/protocols/s3/services/" + svmInfo.svmUUID + "/buckets"
 	statusCode, _ := performHttpPost(mgmInfo.username, mgmInfo.password, urlString, []byte(jsonString))
-	if statusCode == 202 {
-		klog.Infof("S3 Bucket job has been created: https://docs.netapp.com/us-en/ontap-restapi/ontap/post-protocols-s3-buckets.html#response")
-		return true
-	} else if statusCode == 201 {
+	if statusCode == 201 {
 		klog.Infof("S3 Bucket has been created: https://docs.netapp.com/us-en/ontap-restapi/ontap/post-protocols-s3-buckets.html#response")
+		return true
+	} else if statusCode == 202 {
+		klog.Infof("S3 Bucket job has been created: https://docs.netapp.com/us-en/ontap-restapi/ontap/post-protocols-s3-buckets.html#response")
+		// In this case we may still want to check if the bucket exists after maybe 5 seconds?
+		// checkIfS3BucketExists()...
 		return true
 	}
 	klog.Errorf("Error when submitting the request to create a bucket") // TODO add error string
@@ -321,7 +323,6 @@ func checkIfS3BucketExists(mgmInfo managementInfo, svmUuid string, requestedBuck
 	// Build the request
 	urlString := "https://" + mgmInfo.managementIP + "/api/protocols/s3/services/" + svmUuid + "/buckets"
 	statusCode, _ := performHttpGet(mgmInfo.username, mgmInfo.password, urlString)
-	// statusCode, response := performHttpGet(mgmInfo.username, mgmInfo.password, urlString)
 	if statusCode != 200 {
 		klog.Errorf("Error interacting with Netapp API for checking if S3 bucket exists:") // TODO add error message
 		// thing is we dont want to return false here because this response indicates a failed API call
@@ -329,7 +330,7 @@ func checkIfS3BucketExists(mgmInfo managementInfo, svmUuid string, requestedBuck
 		return true
 	}
 	// Check the response and go through it.
-	//
+	// TODO
 	return true
 }
 

--- a/cmd/ontap-cvo.go
+++ b/cmd/ontap-cvo.go
@@ -177,7 +177,7 @@ func getOnPrem(ownerEmail string, client *kubernetes.Clientset) (string, bool) {
 	// Don't forget to create a secret in the namespace for authentication with azure in the namespace
 	// for me in aaw-dev its under jose-matsuda
 	// TODO change to das? for the location of secrets
-	secret, err := client.CoreV1().Secrets("netapp").Get(context.Background(), "netapp-regi-secret", metav1.GetOptions{})
+	secret, err := client.CoreV1().Secrets("netapp").Get(context.Background(), "microsoft-graph-api-secret", metav1.GetOptions{})
 	if err != nil {
 		klog.Infof("An Error Occured while getting registration secret %v", err)
 		return "", false


### PR DESCRIPTION
[BTIS-473](https://jirab.statcan.ca/browse/BTIS-473)

Creates a new bucket given a name and path. 

As of writing 13/09/2024 the following is true and must be done

1. We must still implement the hash function, this can be called in the `createS3Bucket` or earlier and just passed down. The investigation of this is in [BTIS-471](https://jirab.statcan.ca/browse/BTIS-471) 
2. Must call the `createS3Bucket`. This should only be called after a `checkIfS3BucketExists` function completes and returns "no it does not exist so we must create it" This is a TODO in [BTIS-482](https://jirab.statcan.ca/browse/BTIS-482)
3. We must persist the ManagementInfo secret (named netapp-management-information) in a namespace (right now assumed as Netapp as thats where a flow is opened, but can be changed to das). There is a ticket [here](https://jirab.statcan.ca/browse/BTIS-199) to persist that as well as other information (graph api connection info)
4. We must create the resulting error configmap should the create fail

