### PR TITLE
chore(memory limit): up again

### DIFF
--- a/cmd/quotas.go
+++ b/cmd/quotas.go
@@ -31,7 +31,7 @@ var defaultResources = corev1.ResourceList{
 
 	// Memory
 	"requests.memory": *resource.NewScaledQuantity(96, resource.Giga),
-	"limits.memory":   *resource.NewScaledQuantity(196, resource.Giga),
+	"limits.memory":   *resource.NewScaledQuantity(500, resource.Giga),
 
 	// Storage
 	"requests.storage": *resource.NewScaledQuantity(1, resource.Tera),


### PR DESCRIPTION
there exist current users with 17 shares (and thus a limit of 170 at min is needed, + any requests they use for say a maximum notebook)
The solace that we have is that the `limit` won't be under constant use and is not reserved. 